### PR TITLE
Removing sierra-wrapper reference and adding @nypl/sierra-wrapper.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 
 const avro = require('avsc')
-const wrapper = require('sierra-wrapper')
+const wrapper = require('@nypl/sierra-wrapper')
 const config = require('config')
 const retry = require('retry')
 const bunyan = require('bunyan')

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,4 +1,4 @@
-const wrapper = require('sierra-wrapper')
+const wrapper = require('@nypl/sierra-wrapper')
 const _ = require('highland')
 
 /**

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
   },
   "homepage": "https://github.com/NYPL-discovery/sierra-retriever",
   "dependencies": {
+    "@nypl/sierra-wrapper": "0.2.0",
     "avsc": "^4.1.11",
     "aws-sdk": "^2.14.0",
+    "bunyan": "^1.8.10",
     "config": "^1.25.1",
     "highland": "^2.10.2",
+    "request": "^2.81.0",
     "retry": "^0.10.1",
-    "sierra-wrapper": "^0.1.4",
-    "request":"^2.81.0",
-    "standard": "^10.0.0",
-    "bunyan": "^1.8.10"
+    "standard": "^10.0.0"
   },
   "devDependencies": {
     "mocha": "^3.2.0",


### PR DESCRIPTION
Fixes #17 

Is `lib/api.js` being used anywhere? I updated the reference there but the file itself doesn't seem to be used.